### PR TITLE
Extend reboot delay time after last packet

### DIFF
--- a/hw/bsp/versiboard2/README.md
+++ b/hw/bsp/versiboard2/README.md
@@ -1,0 +1,3 @@
+To deploy on versiboard2 you will need to use an external programmer such as blackmagic probe or JLink.
+
+If you are using the .bin file in the `release_images` directory then a command like `loadfile versiboard2-tinyuf2.bin 0x60000000` should do the trick.

--- a/src/msc.c
+++ b/src/msc.c
@@ -295,7 +295,7 @@ int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset, uint8_t* 
                 if (write_state.numWritten >= write_state.numBlocks) {
                     board_flash_flush();
 
-                    reset_millis = board_millis() + 30;
+                    reset_millis = board_millis() + 100;
                 }
             }
         } else {


### PR DESCRIPTION
This extends the delay after last packet slightly, which stops (my) linux box from complaining the drive disappeared too quickly.  I will keep testing with this patch.

(Also the README.md for Versiboard2, which seemed to get missed somehow)
