### PR TITLE
mimxrt101x: Include start of flash in .ld

### DIFF
--- a/hw/chip/mimxrt10xx/mimxrt101x/MIMXRT1011xxxxx_flexspi_nor.ld
+++ b/hw/chip/mimxrt10xx/mimxrt101x/MIMXRT1011xxxxx_flexspi_nor.ld
@@ -5,6 +5,7 @@ _minimum_heap_size = 0;
 
 MEMORY
 {
+    FLASH_START (rx)  : ORIGIN = 0x60000000, LENGTH = 1K
     FLASH_CONFIG (rx) : ORIGIN = 0x60000400, LENGTH = 3K
     FLASH_IVT (rx)    : ORIGIN = 0x60001000, LENGTH = 4K
     FLASH_ISR (rx)    : ORIGIN = 0x60002000, LENGTH = 1K
@@ -19,6 +20,12 @@ __RAM_VECTOR_TABLE_SIZE_BYTES = 0;
 
 SECTIONS
 {
+    .flash :
+    {
+        . = ALIGN(4);
+        BYTE(0x00)
+    } > FLASH_START
+
     .flash_config :
     {
         . = ALIGN(4);


### PR DESCRIPTION
This ensures that the .bin file that is generated
starts from 0x60000000. Without this, it will start
from 0x60000400 which makes it harder to work with.